### PR TITLE
0722 : linked list

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+  "configurations": [
+    {
+      "name": "macos-clang-arm64",
+      "includePath": [
+        "${workspaceFolder}/**"
+      ],
+      "compilerPath": "/usr/bin/clang",
+      "cStandard": "${default}",
+      "cppStandard": "${default}",
+      "intelliSenseMode": "macos-clang-arm64",
+      "compilerArgs": [
+        ""
+      ]
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "C/C++ Runner: Debug Session",
+      "type": "lldb",
+      "request": "launch",
+      "args": [],
+      "cwd": "/Users/chahyeonjeong/Desktop/jjeong_copull",
+      "program": "/Users/chahyeonjeong/Desktop/jjeong_copull/build/Debug/outDebug"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,59 @@
+{
+  "C_Cpp_Runner.cCompilerPath": "clang",
+  "C_Cpp_Runner.cppCompilerPath": "clang++",
+  "C_Cpp_Runner.debuggerPath": "lldb",
+  "C_Cpp_Runner.cStandard": "",
+  "C_Cpp_Runner.cppStandard": "",
+  "C_Cpp_Runner.msvcBatchPath": "C:/Program Files/Microsoft Visual Studio/VR_NR/Community/VC/Auxiliary/Build/vcvarsall.bat",
+  "C_Cpp_Runner.useMsvc": false,
+  "C_Cpp_Runner.warnings": [
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wshadow",
+    "-Wformat=2",
+    "-Wcast-align",
+    "-Wconversion",
+    "-Wsign-conversion",
+    "-Wnull-dereference"
+  ],
+  "C_Cpp_Runner.msvcWarnings": [
+    "/W4",
+    "/permissive-",
+    "/w14242",
+    "/w14287",
+    "/w14296",
+    "/w14311",
+    "/w14826",
+    "/w44062",
+    "/w44242",
+    "/w14905",
+    "/w14906",
+    "/w14263",
+    "/w44265",
+    "/w14928"
+  ],
+  "C_Cpp_Runner.enableWarnings": true,
+  "C_Cpp_Runner.warningsAsError": false,
+  "C_Cpp_Runner.compilerArgs": [],
+  "C_Cpp_Runner.linkerArgs": [],
+  "C_Cpp_Runner.includePaths": [],
+  "C_Cpp_Runner.includeSearch": [
+    "*",
+    "**/*"
+  ],
+  "C_Cpp_Runner.excludeSearch": [
+    "**/build",
+    "**/build/**",
+    "**/.*",
+    "**/.*/**",
+    "**/.vscode",
+    "**/.vscode/**"
+  ],
+  "C_Cpp_Runner.useAddressSanitizer": false,
+  "C_Cpp_Runner.useUndefinedSanitizer": false,
+  "C_Cpp_Runner.useLeakSanitizer": false,
+  "C_Cpp_Runner.showCompilationTime": false,
+  "C_Cpp_Runner.useLinkTimeOptimization": false,
+  "C_Cpp_Runner.msvcSecureNoWarnings": false
+}

--- a/1158.cpp
+++ b/1158.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <list>
+
+using namespace std;
+
+int n, k;
+
+int main() {
+    ios::sync_with_stdio(0);
+    cin.tie(0);
+
+    cin >> n >> k;
+
+    list<int> L;
+    for (int i = 1; i <= n; i++) {
+        L.push_back(i);
+    }
+
+    auto cursor = L.begin();
+    cout << "<";
+
+    while (!L.empty()) {
+        
+        for (int i = 0; i < k - 1; i++) {
+            cursor++;
+            if (cursor == L.end()) cursor = L.begin();
+        }
+
+       
+        cout << *cursor;
+        cursor = L.erase(cursor); 
+        if (cursor == L.end()) cursor = L.begin(); 
+
+        if (!L.empty()) cout << ", ";
+    }
+
+    cout << ">\n";
+    return 0;
+}


### PR DESCRIPTION
closes #1 

## 시간복잡도
C++ STL의 list<int>를 사용해서 리스트를 순회하며 k번째 원소를 제거를 n번 반복하기 떄문에 O(nk)를 가짐
## 구현
C++ STL의 list<int>를 사용
list는 양방향 연결 리스트로 구현되어있기 때문에 iterator를 사용하면 리스트를 순환 탐색하기 편하며, 중간 노드 삭제가 O(1) 복잡도를 가짐

1. 1부터 n까지 숫자를 리스트에 삽입
```c++
list<int> L;
for (int i = 1; i <= n; i++) {
    L.push_back(i);
}
```
2. 현재 제거할 위치를 가리키는 iterator 설정
`
auto cursor = L.begin();
`

3. K번째 사람을 찾기 위해 커서를 (k-1)번 이동
리스트의 끝에 도달하면 다시 처음으로 돌아가 원형 구조처럼 순회
```c++
for (int i = 0; i < k - 1; i++) {
    cursor++;
    if (cursor == L.end()) cursor = L.begin();
}
```

4. 현재 위치에 있는 사람을 제거하고 출력
리스트가 끝났다면 다시 처음으로
```c++
cout << *cursor;
cursor = L.erase(cursor);
if (cursor == L.end()) cursor = L.begin();
```
