### PR TITLE
0805-deque

### DIFF
--- a/11003.cpp
+++ b/11003.cpp
@@ -1,0 +1,36 @@
+#include<iostream>
+#include<deque>
+
+using namespace std;
+int n;
+int L;
+long long k;
+long long minium;
+int main(){
+    ios::sync_with_stdio(0);
+    cin.tie(0);
+
+    deque<pair<int, int>> dq;
+
+    cin>>n>>L;
+
+    for(int i = 0; i<n; i++){
+
+        int k;
+        cin>>k;
+
+        while (!dq.empty() && dq.back().first > k) {
+            dq.pop_back();
+        }
+
+        dq.push_back({k, i});
+
+        if (dq.front().second <= i - L) {
+            dq.pop_front();
+        }
+
+        cout << dq.front().first << " ";
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## 시간복잡도
C++ STL의 deque<int>를 사용 => 양쪽 끝에서 삽입과 삭제가 가능
맨 뒤의 원소보다 입력 받은 값이 작으면 맨 뒤 제거하고 뒤에 삽입, 이후에 들어오는 값과 맨 뒤의 원소 크기 비교
최솟값들을 덱에 저장

## 구현 1 - 슬라이딩 윈도우 문제
1. 입력 받은 원소와 현재 덱의 맨 뒤에 있는 원소와 비교 (새로 들어온 원소와 이전의 최솟값 중 더 작은값을 덱에 저장)
덱에 들어있는 원소보다 현재 입력받은 원소가 더 작다면 덱에 있는 원소 pop
```c++
        int k;
        cin>>k;

        while (!dq.empty() && dq.back().first > k) {
            dq.pop_back();
        }
```
2. 인덱스 비교 : 인덱스 범위 초과 시 pop
```c++
 if (dq.front().second <= i - L) {
            dq.pop_front();
        }

```